### PR TITLE
Update how we call the EventEmitter constructor from extended objects

### DIFF
--- a/lib/simperium/bucket.js
+++ b/lib/simperium/bucket.js
@@ -8,7 +8,7 @@ var arglock = require('./util/fn').arglock;
 module.exports = Bucket;
 
 function Bucket(name, storeProvider) {
-  EventEmitter(this);
+  EventEmitter.call(this);
   this.name = name;
   this.store = storeProvider(this);
 }

--- a/lib/simperium/client.js
+++ b/lib/simperium/client.js
@@ -177,7 +177,7 @@ Client.prototype.onClose = function(){
 function Heartbeat(seconds, onBeat) {
   this.count = 0;
   this.seconds = seconds;
-  EventEmitter(this);
+  EventEmitter.call(this);
 
   if (onBeat) this.on('beat', onBeat);
 }
@@ -215,7 +215,7 @@ Heartbeat.prototype.stop = function() {
 
 function ReconnectionTimer(interval, onTripped) {
 
-  EventEmitter(this);
+  EventEmitter.call(this);
 
   this.started = false;
 


### PR DESCRIPTION
`EventEmitter(this)` causes issues on Node > 4.0, and switching to
`EventEmitter.call(this)` properly sets the `this` context.

Fixes #10