### PR TITLE
Listen to bucket updates while indexing

### DIFF
--- a/lib/simperium/channel.js
+++ b/lib/simperium/channel.js
@@ -31,11 +31,13 @@ function Channel(appid, access_token, bucket, store){
   var channel = this;
 
   this.appid = appid;
+  this.access_token = access_token;
   this.bucket = bucket;
   this.store = store;
-  this.access_token = access_token;
 
   this.session_id = 'node-' + uuid.v4();
+  this.index_last_id = null;
+  this.index_cv = null;
 
   var message = this.message = new EventEmitter();
 
@@ -110,6 +112,7 @@ function Channel(appid, access_token, bucket, store){
     });
 
   bucket.on('reload', this.onReload.bind(this));
+  bucket.on('update', this.onBucketUpdate.bind(this));
 
   this.on('change-version', internal.updateChangeVersion.bind(this));
 
@@ -133,6 +136,19 @@ Channel.prototype.onReload = function() {
   this.store.eachGhost(function(ghost) {
     emit(ghost.key, ghost.data);
   });
+};
+
+Channel.prototype.onBucketUpdate = function(noteId, data) {
+    if (this.index_last_id == null || this.index_cv == null) {
+      return;
+    } else if (this.index_last_id == noteId) {
+      // Indexing has finished
+      this.bucket.isIndexing = false;
+      this.emit('index', this.index_cv);
+
+      this.index_last_id = null;
+      this.index_cv = null;
+    }
 };
 
 Channel.prototype.onAuth = function(data){
@@ -183,13 +199,15 @@ Channel.prototype.onIndex = function(data){
       cv      = page.current,
       update  = internal.updateObjectVersion.bind(this);
 
+  var objectId;
   objects.forEach(function(object, i){
+    objectId = object.id;
     update(object.id, object.v, object.d);
   });
 
   if (!mark) {
-    this.bucket.isIndexing = false;
-    this.emit('index', page.current);
+    this.index_last_id = objectId;
+    this.index_cv = cv;
   } else {
     this.sendIndexRequest(mark);
   }

--- a/lib/simperium/channel.js
+++ b/lib/simperium/channel.js
@@ -112,7 +112,8 @@ function Channel(appid, access_token, bucket, store){
     });
 
   bucket.on('reload', this.onReload.bind(this));
-  bucket.on('update', this.onBucketUpdate.bind(this));
+  this.bucketUpdateListener = this.onBucketUpdate.bind(this);
+  bucket.on('update', this.bucketUpdateListener);
 
   this.on('change-version', internal.updateChangeVersion.bind(this));
 
@@ -148,6 +149,7 @@ Channel.prototype.onBucketUpdate = function(noteId, data) {
 
       this.index_last_id = null;
       this.index_cv = null;
+      this.bucket.removeListener('update', this.bucketUpdateListener);
     }
 };
 
@@ -490,7 +492,6 @@ internal.removeAndSend = function(id, object) {
 // We've receive a full object from the network. Update the local instance and
 // notify of the new object version
 internal.updateObjectVersion = function(id, version, data, original, patch, acknowledged){
-
   var notify;
   // If it's not an ack, it's a change initiated on a different client
   // we need to provide a way for the current client to respond to


### PR DESCRIPTION
Corrects a race condition where the `index` emit could fire before the bucket actually saved the objects.