### PR TITLE
Handle failed authentication attempts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
 		"eol-last": 1,
 		"indent": [ 1, "tab", { "SwitchCase": 1 } ],
 		"key-spacing": 1,
+		"keyword-spacing": [ 1 ],
 		// Most common is "Emitter", should be improved
 		"new-cap": 1,
 		"no-cond-assign": 2,
@@ -58,7 +59,6 @@
 		"quote-props": [ 1, "as-needed" ],
 		"quotes": [ 1, "single", "avoid-escape" ],
 		"semi-spacing": 1,
-		"space-after-keywords": [ 1, "always" ],
 		"space-before-blocks": [ 1, "always" ],
 		"space-before-function-paren": [ 1, "never" ],
 		// Our array literal index exception violates this rule

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 sudo: false
 before_install:
-  - npm install -g eslint babel-eslint
+  - npm install -g eslint@2.2 babel-eslint
 script:
   - eslint .
   - npm test
 node_js:
-  - "0.12"
   - "4.0"
   - "5.0"

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -40,7 +40,13 @@ Auth.prototype.request = function( endpoint, body ) {
 			} );
 
 			res.on( 'end', () => {
-				var user = User.fromJSON( responseData );
+				var user;
+
+				try {
+					user = User.fromJSON( responseData );
+				} catch ( e ) {
+					return reject( new Error( responseData ) );
+				}
 				this.emit( 'authorize', user );
 				resolve( user );
 			} );


### PR DESCRIPTION
Previously when making a login attempt for a wrong username or password, the server was responding with plain text which threw an exception when attempting to create the user object. This is because `JSON.parse()` couldn't handle it.

**Bad username** - `unknown username: bad-email@example.com`
**Bad password** - `invalid password`

Now we return `null` in these cases to indicate the failures.

cc: @roundhill @beaucollins 