### PR TITLE
Send isIndexing when calling store.update() from Bucket

### DIFF
--- a/src/simperium/bucket.js
+++ b/src/simperium/bucket.js
@@ -28,7 +28,7 @@ Bucket.prototype.update = function( id, data, options, callback ) {
 	if ( typeof options === 'function' ) {
 		callback = options;
 	}
-	return this.store.update( id, data, callback );
+	return this.store.update( id, data, this.isIndexing, callback );
 };
 
 Bucket.prototype.touch = function( id, callback ) {

--- a/test/simperium/bucket_test.js
+++ b/test/simperium/bucket_test.js
@@ -34,6 +34,18 @@ describe( 'Bucket', function() {
 		} );
 	} );
 
+	it( 'should update with options', function( done ) {
+		var id = 'thing',
+			object = {one: 'two'}
+
+		bucket.update( id, object, {}, function() {
+			bucket.get( id, function( err, savedObject ) {
+				assert.deepEqual( object, savedObject );
+				done();
+			} )
+		} )
+	} );
+
 	it( 'should delete object data', function( done ) {
 		store.objects = {
 			hello: {title: 'hola mundo'}

--- a/test/simperium/default_storage_test.js
+++ b/test/simperium/default_storage_test.js
@@ -1,13 +1,12 @@
-import assert, { fail } from 'assert'
+import assert from 'assert'
 import Bucket from '../../src/simperium/bucket'
 import defaultStore from '../../src/simperium/storage/default'
 
 describe( 'default store', function() {
-	var bucket, store;
+	var bucket;
 
 	beforeEach( function() {
 		bucket = new Bucket( 'things', defaultStore );
-		store = bucket.store;
 	} )
 
 	it( 'should store object update', function( done ) {
@@ -16,7 +15,7 @@ describe( 'default store', function() {
 
 		bucket.update( id, data, function() {
 			bucket.get( id, function( err, object ) {
-				assert.deepEqual( object, { data, id }  );
+				assert.deepEqual( object, { data, id } );
 				done();
 			} );
 		} );

--- a/test/simperium/default_storage_test.js
+++ b/test/simperium/default_storage_test.js
@@ -1,0 +1,36 @@
+import assert, { fail } from 'assert'
+import Bucket from '../../src/simperium/bucket'
+import defaultStore from '../../src/simperium/storage/default'
+
+describe( 'default store', function() {
+	var bucket, store;
+
+	beforeEach( function() {
+		bucket = new Bucket( 'things', defaultStore );
+		store = bucket.store;
+	} )
+
+	it( 'should store object update', function( done ) {
+		var id = 'thing',
+			data = {one: 'two'};
+
+		bucket.update( id, data, function() {
+			bucket.get( id, function( err, object ) {
+				assert.deepEqual( object, { data, id }  );
+				done();
+			} );
+		} );
+	} );
+
+	it( 'should update with options', function( done ) {
+		var id = 'thing',
+			data = {one: 'two'}
+
+		bucket.update( id, data, {}, function() {
+			bucket.get( id, function( err, object ) {
+				assert.deepEqual( object, { data, id } );
+				done();
+			} )
+		} )
+	} );
+} )

--- a/test/simperium/mock_bucket_store.js
+++ b/test/simperium/mock_bucket_store.js
@@ -15,10 +15,10 @@ BucketStore.prototype.get = function( id, callback ) {
 	} );
 };
 
-BucketStore.prototype.update = function( id, object, callback ) {
+BucketStore.prototype.update = function( id, object, isIndexing, callback ) {
 	this.objects[id] = object;
 	process.nextTick( function() {
-		if ( callback ) callback( null, {id: id, data: object} );
+		if ( callback ) callback( null, {id: id, data: object, isIndexing: isIndexing} );
 	} );
 };
 


### PR DESCRIPTION
`store.update()` has an arity of 4, but we were calling it with an
arity of 3, which means it probably never worked at all (`callback` is
always not a function and triggers an uncaught exception).

Fix arguments to `store.update()`

Fixes #29