### PR TITLE
Re-sends sent changes on reconnect

### DIFF
--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -164,18 +164,20 @@ describe( 'Channel', function() {
 		} );
 
 		it( 'should resend sent but unacknowledged changes on reconnect', () => new Promise( resolve => {
-			channel.localQueue.sent['fake-ccid'] = { fake: 'change' }
+			channel.localQueue.sent['fake-ccid'] = { fake: 'change', ccid: 'fake-ccid' }
 
 			channel.on( 'send', cycle(
-				() => channel.handleMessage( 'i:{"index":[],"current":"cv"}'),
-				m => {
+				m => setImmediate( () => {
+					equal( m, 'i:1:::10' )
+					channel.handleMessage( 'i:{"index":[],"current":"cv"}' )
+				} ),
+				m => setImmediate( () => {
+					equal( m, 'c:{"fake":"change","ccid":"fake-ccid"}')
 					resolve()
-				}
+				} )
 			) )
 
 			channel.handleMessage( 'auth:user@example.com' )
-			
-			channel.emit( 'ready' )
 		} ) )
 
 		it( 'should send remove operation', function( done ) {

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -172,7 +172,7 @@ describe( 'Channel', function() {
 					channel.handleMessage( 'i:{"index":[],"current":"cv"}' )
 				} ),
 				m => setImmediate( () => {
-					equal( m, 'c:{"fake":"change","ccid":"fake-ccid"}')
+					equal( m, 'c:{"fake":"change","ccid":"fake-ccid"}' )
 					resolve()
 				} )
 			) )


### PR DESCRIPTION
After auth and index and/or receive changes from server emits a 'ready' event for the channel.
After authing, listens for one ready event and resends any changes in the local queue