### PR TITLE
Bucket requests ghost at "sv" when local version is not up to date

### DIFF
--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -141,10 +141,10 @@ internal.requestObjectVersion = function( id, version ) {
 	return new Promise( resolve => {
 		this.once( `version.${ id }.${ version }`, data => {
 			resolve( data );
-		} )
-		this.send( `e:${ id }.${ version }` )
-	} )
-}
+		} );
+		this.send( `e:${ id }.${ version }` );
+	} );
+};
 
 internal.applyChange = function( change, ghost ) {
 	var acknowledged = internal.findAcknowledgedChange.bind( this )( change ),

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -137,6 +137,15 @@ internal.findAcknowledgedChange = function( change ) {
 	}
 };
 
+internal.requestObjectVersion = function( id, version ) {
+	return new Promise( resolve => {
+		this.once( `version.${ id }.${ version }`, data => {
+			resolve( data );
+		} )
+		this.send( `e:${ id }.${ version }` )
+	} )
+}
+
 internal.applyChange = function( change, ghost ) {
 	var acknowledged = internal.findAcknowledgedChange.bind( this )( change ),
 		error,
@@ -164,14 +173,15 @@ internal.applyChange = function( change, ghost ) {
 
 	if ( change.o === operation.MODIFY ) {
 		if ( ghost && ( ghost.version !== change.sv ) ) {
-			// throw new Error( "Source version and ghost version do not match" );
+			internal.requestObjectVersion.call( this, change.id, change.sv ).then( data => {
+				internal.applyChange.call( this, change, { version: change.sv, data } )
+			} );
 			return;
 		}
 
 		original = ghost.data;
 		patch = change.v;
 		modified = jsondiff.apply_object_diff( original, patch );
-
 		return internal.updateObjectVersion.bind( this )( change.id, change.ev, modified, original, patch, acknowledged )
 			.then( emit );
 	} else if ( change.o === operation.REMOVE ) {
@@ -411,6 +421,7 @@ Channel.prototype.onVersion = function( data ) {
 
 	this.emit( 'version', ghost.id, ghost.version, ghost.data );
 	this.emit( 'version.' + ghost.id, ghost.id, ghost.version, ghost.data );
+	this.emit( 'version.' + ghost.id + '.' + ghost.version, ghost.data );
 };
 
 function NetworkQueue() {

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -464,15 +464,15 @@ describe( 'Channel', function() {
 		it( 'should request entire object when source version is out of date', ( done ) => {
 			var change = {o: 'M', id: 'thing', sv: 1, ev: 2, ccid: 'abc', cv: 'new-cv', v: diff( { hello: 'mundo'}, {hello: 'world'} ) };
 			channel.once( 'send', ( data ) => {
-				equal( data, `e:${change.id}.${change.sv}` )
+				equal( data, `e:${change.id}.${change.sv}` );
 				channel.once( 'change-version', ( cv ) => {
-					equal( cv, 'new-cv' )
-					done()
-				} )
-				channel.handleMessage( `e:${change.id}.${change.sv}\n${JSON.stringify( { data: { hello: 'mundo'} } )} ` )
-			} )
-			channel.handleMessage( `c:[${JSON.stringify( change )}]` )
-		} )
+					equal( cv, 'new-cv' );
+					done();
+				} );
+				channel.handleMessage( `e:${change.id}.${change.sv}\n${JSON.stringify( { data: { hello: 'mundo'} } )} ` );
+			} );
+			channel.handleMessage( `c:[${JSON.stringify( change )}]` );
+		} );
 	} );
 } );
 

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -460,6 +460,19 @@ describe( 'Channel', function() {
 			} );
 			channel.handleMessage( 'auth:user@example.com' );
 		} );
+
+		it( 'should request entire object when source version is out of date', ( done ) => {
+			var change = {o: 'M', id: 'thing', sv: 1, ev: 2, ccid: 'abc', cv: 'new-cv', v: diff( { hello: 'mundo'}, {hello: 'world'} ) };
+			channel.once( 'send', ( data ) => {
+				equal( data, `e:${change.id}.${change.sv}` )
+				channel.once( 'change-version', ( cv ) => {
+					equal( cv, 'new-cv' )
+					done()
+				} )
+				channel.handleMessage( `e:${change.id}.${change.sv}\n${JSON.stringify( { data: { hello: 'mundo'} } )} ` )
+			} )
+			channel.handleMessage( `c:[${JSON.stringify( change )}]` )
+		} )
 	} );
 } );
 


### PR DESCRIPTION
If the bucket were to miss a change version, a ghost object could become out of date and future changes will fail to apply to the version.

This change detects when local versions are out of date and updates them to the `change.sv` and attempts to apply the change again.