### PR TITLE
Send full object on 405 or 440 error.

### DIFF
--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -199,9 +199,11 @@ internal.handleChangeError = function( err, change, acknowledged ) {
 		case CODE_INVALID_VERSION:
 		case CODE_INVALID_DIFF: // Invalid version or diff, send full object back to server
 			if ( ! change.hasSentFullObject ) {
-				change.d = this.store.get( change.id );
-				change.hasSentFullObject = true;
-				this.localQueue.queue( change );
+				this.store.get( change.id ).then( object => {
+					change.d = object;
+					change.hasSentFullObject = true;
+					this.localQueue.queue( change );
+				} );
 			} else {
 				this.localQueue.dequeueChangesFor( change.id );
 			}

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -5,9 +5,12 @@ import { parseMessage, parseVersionMessage, change as change_util } from './util
 import JSONDiff from './jsondiff'
 import uuid from 'node-uuid'
 
-const jsondiff = new JSONDiff( {list_diff: false} )
+const jsondiff = new JSONDiff( {list_diff: false} );
 
-const UNKNOWN_CV = '?'
+const UNKNOWN_CV = '?';
+const CODE_INVALID_VERSION = 405;
+const CODE_EMPTY_RESPONSE = 412;
+const CODE_INVALID_DIFF = 440;
 
 var operation = {
 	MODIFY: 'M',
@@ -193,7 +196,18 @@ internal.applyChange = function( change, ghost ) {
 
 internal.handleChangeError = function( err, change, acknowledged ) {
 	switch ( err.code ) {
-		case 412: // Change causes no change, just acknowledge it
+		case CODE_INVALID_VERSION:
+		case CODE_INVALID_DIFF: // Invalid version or diff, send full object back to server
+			if ( ! change.hasSentFullObject ) {
+				change.d = this.store.get( change.id );
+				change.hasSentFullObject = true;
+				this.localQueue.queue( change );
+			} else {
+				this.localQueue.dequeueChangesFor( change.id );
+			}
+
+			break;
+		case CODE_EMPTY_RESPONSE: // Change causes no change, just acknowledge it
 			internal.updateAcknowledged.call( this, acknowledged );
 			break;
 		default:
@@ -306,7 +320,6 @@ inherits( Channel, EventEmitter );
 
 Channel.prototype.handleMessage = function( data ) {
 	var message = parseMessage( data );
-
 	this.message.emit( message.command, message.data );
 };
 

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -383,6 +383,26 @@ describe( 'Channel', function() {
 				channel.localQueue.queue( change );
 			} );
 		} );
+
+		it( 'should send full object on 405 error', function( done ) {
+			// if a change is sent and a 405 is returned, the full object should be sent
+			// Add an object to the store
+			channel.store.put( 'thing', 1, {} );
+
+			// channel should not emit error during this change
+			channel.on( 'error', function( e ) {
+				done( e );
+			} );
+
+			// ensure that a change with a `d` property is added to the queue
+			channel.localQueue.once( 'queued', function( id, change, queue ) {
+				assert.ok( queue[0].d );
+				done();
+			} );
+
+			// send a 405 error
+			channel.handleMessage( 'c:' + JSON.stringify( [{error: 405, id: 'thing', ccids: ['abc']}] ) );
+		} );
 	} );
 
 	it( 'should request index when cv is unknown', done => {


### PR DESCRIPTION
Mirrors how the simperium android library handles a 405 and 440 error.