### PR TITLE
Revisions: Increase count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -645,6 +645,10 @@ LocalQueue.prototype.resendSentChanges = function() {
 function collectionRevisions( channel, id, callback ) {
 	var expectedVersions = -1;
 	var onGhostRetrieved = function( ghost ) {
+		// the default bucket options allow for storing
+		// the 60 most-recent revisions of a note plus
+		// 100 archive versions (these store one out of
+		// every ten versions). we'll get up to this many
 		var version = Math.min( ghost.version, 160 );
 		var i;
 		expectedVersions = version;

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -645,7 +645,7 @@ LocalQueue.prototype.resendSentChanges = function() {
 function collectionRevisions( channel, id, callback ) {
 	var expectedVersions = -1;
 	var onGhostRetrieved = function( ghost ) {
-		var version = Math.min( ghost.version, 30 );
+		var version = Math.min( ghost.version, 160 );
 		var i;
 		expectedVersions = version;
 


### PR DESCRIPTION
The default revision collector grabs at most 30 revisions of an object
from a bucket but the default numbers for the revision count and
revision (ten) count are 60 and 100, respectively.

This patch bumps up the number of revisions collected so that for apps
without custom settings they can fetch all of the saved revisions.

More thorough work is needed because we have a tradeoff between revision
counts and latency in fetching them. If we could return the list of
revisions repeatedly as new ones come in this would not be a problem.