### PR TITLE
Set bucket isIndexing property as soon as indexing finishes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -399,6 +399,11 @@ Channel.prototype.onIndex = function( data ) {
 		cv			= page.current,
 		update	= internal.updateObjectVersion.bind( this );
 
+	if ( !mark ) {
+		// Let the bucket know straight away that indexing has finished
+		this.bucket.isIndexing = false;
+	}
+
 	var objectId;
 	objects.forEach( function( object ) {
 		objectId = object.id;
@@ -674,4 +679,3 @@ function collectionRevisions( channel, id, callback ) {
 		callback( e );
 	} );
 }
-


### PR DESCRIPTION
I've been working on this issue: https://github.com/Automattic/simplenote-electron/issues/641

The app wasn't updating properly because it was checking the `isIndexing` property of the `update` bucket call, which is being set to `false` after the new objects are updated so it skipped rendering the notes.

We can fix this by telling the bucket that the indexing has completed before it processes the objects it receives in the final indexing call.

**To Test**
* Connect up this branch to `simplenote-electron`
* Sign in with a test account. You'll see your notes.
* Sign out of the account and sign in to another account. You should see your notes load as well.