### PR TITLE
Allow an optional 'provider' param to be passed when creating a user.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -20,9 +20,13 @@ Auth.prototype.authorize = function( username, password ) {
 	return promise;
 }
 
-Auth.prototype.create = function( username, password ) {
-	var body = JSON.stringify( { username: username, password: password } ),
-		promise = this.request( 'create/', body );
+Auth.prototype.create = function ( username, password, provider ) {
+	var userData = { username, password };
+	if ( provider ) {
+		userData.provider = provider;
+	}
+	var body = JSON.stringify( userData ),
+	    promise = this.request( 'create/', body );
 
 	return promise;
 }

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -20,7 +20,7 @@ Auth.prototype.authorize = function( username, password ) {
 	return promise;
 }
 
-Auth.prototype.create = function ( username, password, provider ) {
+Auth.prototype.create = function( username, password, provider ) {
 	var userData = { username, password };
 	if ( provider ) {
 		userData.provider = provider;


### PR DESCRIPTION
Simplenote signups require a 'provider' parameter to be provided in order to create an account on Google App Engine, this PR adds support for that as optional.

Note: This lib could use some es6-ification, but I've left that for another day ;)

