### PR TITLE
Adds method to fetch an object's version

### DIFF
--- a/src/simperium/bucket.js
+++ b/src/simperium/bucket.js
@@ -31,6 +31,10 @@ Bucket.prototype.update = function( id, data, options, callback ) {
 	return this.store.update( id, data, this.isIndexing, callback );
 };
 
+Bucket.prototype.getVersion = function( id, callback ) {
+	callback( null, 0 );
+};
+
 Bucket.prototype.touch = function( id, callback ) {
 	return this.store.get( id, ( e, object ) => {
 		if ( e ) return callback( e );

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -293,6 +293,20 @@ export default function Channel( appid, access_token, bucket, store ) {
 		collectionRevisions( channel, id, callback );
 	};
 
+	bucket.getVersion = function( id, callback ) {
+		store.get( id ).then(
+			( ghost ) => {
+				var version = 0;
+				if ( ghost && ghost.version ) {
+					version = ghost.version;
+				}
+				callback( null, version );
+			},
+			// callback with error if promise fails
+			callback
+		);
+	};
+
 	bucketEvents
 		.on( 'update', internal.diffAndSend.bind( this ) )
 		.on( 'remove', internal.removeAndSend.bind( this ) );

--- a/test/simperium/bucket_test.js
+++ b/test/simperium/bucket_test.js
@@ -56,5 +56,15 @@ describe( 'Bucket', function() {
 			done();
 		} );
 	} );
+
+	it( 'should fetch object version', () => {
+		store.objects = {
+			thing: { other: 'thing' }
+		};
+		bucket.getVersion( 'thing', ( error, version ) => {
+			assert.equal( version, 0 );
+		} );
+	} );
+
 } );
 

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -403,6 +403,31 @@ describe( 'Channel', function() {
 			// send a 405 error
 			channel.handleMessage( 'c:' + JSON.stringify( [{error: 405, id: 'thing', ccids: ['abc']}] ) );
 		} );
+
+		describe( 'with synced object', () => {
+			beforeEach( ( done ) => {
+				var data = { title: 'hola mundo' };
+
+				channel.on( 'acknowledge', function( id ) {
+					done();
+				} );
+
+				channel.on( 'send', function( msg ) {
+					acknowledge( channel, msg );
+				} );
+
+				bucket.update( 'mock-id', data );
+			} );
+
+			it( 'should get version', ( done ) => {
+				bucket.getVersion( 'mock-id', ( error, version ) => {
+					assert.equal( version, 1 );
+					done()
+				} );
+			} );
+
+		} );
+
 	} );
 
 	it( 'should request index when cv is unknown', done => {
@@ -513,7 +538,7 @@ function acknowledge( channel, msg, cv ) {
 			id: change.id,
 			o: change.o,
 			v: change.v,
-			ev: change.sv ? change.sv + 1 : 0,
+			ev: change.sv ? change.sv + 1 : 1,
 			ccids: [change.ccid],
 			cv: cv || uuid.v4()
 		};


### PR DESCRIPTION
Adds `bucket.getVersion` which takes a callback that responds with an object's version.

With a bucket instance you can now request what the current version of the object's ghost is:

```js
bucket.getVersion( 'object-id', ( error, versionNumber ) => {
   dispatch( { type: 'SET_IS_SYNCED', id: 'object-id', synced: versionNumber > 0} );
} );
```