### PR TITLE
Added bucket.hasLocalChanges method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {

--- a/src/simperium/bucket.js
+++ b/src/simperium/bucket.js
@@ -31,6 +31,10 @@ Bucket.prototype.update = function( id, data, options, callback ) {
 	return this.store.update( id, data, this.isIndexing, callback );
 };
 
+Bucket.prototype.hasLocalChanges = function( callback ) {
+	callback( false );
+};
+
 Bucket.prototype.getVersion = function( id, callback ) {
 	callback( null, 0 );
 };

--- a/src/simperium/bucket.js
+++ b/src/simperium/bucket.js
@@ -32,7 +32,7 @@ Bucket.prototype.update = function( id, data, options, callback ) {
 };
 
 Bucket.prototype.hasLocalChanges = function( callback ) {
-	callback( false );
+	callback( null, false );
 };
 
 Bucket.prototype.getVersion = function( id, callback ) {

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -293,6 +293,10 @@ export default function Channel( appid, access_token, bucket, store ) {
 		collectionRevisions( channel, id, callback );
 	};
 
+	bucket.hasLocalChanges = function( callback ) {
+		callback( channel.localQueue.hasChanges() );
+	};
+
 	bucket.getVersion = function( id, callback ) {
 		store.get( id ).then(
 			( ghost ) => {

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -574,8 +574,11 @@ LocalQueue.prototype.queue = function( change ) {
 	if ( !this.ready ) return;
 
 	this.processQueue( change.id );
-}
-;
+};
+
+LocalQueue.prototype.hasChanges = function() {
+	return Object.keys(this.queues).length > 0;
+};
 
 LocalQueue.prototype.dequeueChangesFor = function( id ) {
 	var changes = [], sent = this.sent[id], queue = this.queues[id];

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -294,7 +294,7 @@ export default function Channel( appid, access_token, bucket, store ) {
 	};
 
 	bucket.hasLocalChanges = function( callback ) {
-		callback( channel.localQueue.hasChanges() );
+		callback( null, channel.localQueue.hasChanges() );
 	};
 
 	bucket.getVersion = function( id, callback ) {

--- a/src/simperium/client.js
+++ b/src/simperium/client.js
@@ -71,10 +71,6 @@ Client.prototype.bucket = function( name ) {
 
 	if ( this.open ) channel.onConnect();
 
-	bucket.hasLocalChanges = function() {
-		return channel.localQueue.hasChanges();
-	};
-
 	return bucket;
 };
 

--- a/src/simperium/client.js
+++ b/src/simperium/client.js
@@ -71,6 +71,10 @@ Client.prototype.bucket = function( name ) {
 
 	if ( this.open ) channel.onConnect();
 
+	bucket.hasLocalChanges = function() {
+		return channel.localQueue.hasChanges();
+	};
+
 	return bucket;
 };
 

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -312,7 +312,7 @@ describe( 'Channel', function() {
 
 		it( 'should have local changes on send', function( done ) {
 			channel.once( 'send', function() {
-				bucket.hasLocalChanges( hasChanges => {
+				bucket.hasLocalChanges( ( error, hasChanges ) => {
 					assert.equal( hasChanges, true );
 					done();
 				} );

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -310,6 +310,29 @@ describe( 'Channel', function() {
 			} );
 		} );
 
+		it( 'should have local changes on send', function( done ) {
+			channel.once( 'send', function() {
+				assert.equal( channel.localQueue.hasChanges(), true );
+				done();
+			} );
+
+			store.put( '123', 3, {title: 'hello world'} ).then( function() {
+				bucket.update( '123', {title: 'goodbye world!!'} );
+			} );
+		} );
+
+		it( 'should have no local changes after ack', function( done ) {
+			channel.on( 'acknowledge', function() {
+				assert.equal( channel.localQueue.hasChanges(), false );
+				done();
+			} );
+
+			store.put( '123', 3, {title: 'hello world'} ).then( function() {
+				bucket.update( '123', {title: 'goodbye world!!'} );
+				done();
+			} );
+		} );
+
 		// If receiving a remote change while there are unsent local modifications,
 		// local changes should be rebased onto the new ghost and re-sent
 		it( 'should resolve applying patch to modified object', function( done ) {

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -312,24 +312,14 @@ describe( 'Channel', function() {
 
 		it( 'should have local changes on send', function( done ) {
 			channel.once( 'send', function() {
-				assert.equal( channel.localQueue.hasChanges(), true );
-				done();
+				bucket.hasLocalChanges( hasChanges => {
+					assert.equal( hasChanges, true );
+					done();
+				} );
 			} );
 
 			store.put( '123', 3, {title: 'hello world'} ).then( function() {
 				bucket.update( '123', {title: 'goodbye world!!'} );
-			} );
-		} );
-
-		it( 'should have no local changes after ack', function( done ) {
-			channel.on( 'acknowledge', function() {
-				assert.equal( channel.localQueue.hasChanges(), false );
-				done();
-			} );
-
-			store.put( '123', 3, {title: 'hello world'} ).then( function() {
-				bucket.update( '123', {title: 'goodbye world!!'} );
-				done();
 			} );
 		} );
 


### PR DESCRIPTION
It'd be nice if clients could as if their bucket has any local changes queued up. I've added a method that checks for any changes in the `LocalQueue` of `Channel`.

I think the tests could be written a little better... feedback appreciated.