### PR TITLE
JSONDiff updates flow types for change utils

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ src/simperium/jsondiff
 lib/
 sample/
 examples/
+flow-typed/

--- a/flow-typed/npm/uuid_v3.x.x.js
+++ b/flow-typed/npm/uuid_v3.x.x.js
@@ -1,0 +1,81 @@
+// flow-typed signature: 615e568e95029d58f116dd157e320137
+// flow-typed version: 2b95c0dfc1/uuid_v3.x.x/flow_>=v0.32.x
+
+declare module "uuid" {
+  declare class uuid {
+    static (
+      options?: {|
+        random?: number[],
+        rng?: () => number[] | Buffer
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string,
+
+    static v1(
+      options?: {|
+        node?: number[],
+        clockseq?: number,
+        msecs?: number | Date,
+        nsecs?: number
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string,
+
+    static v4(
+      options?: {|
+        random?: number[],
+        rng?: () => number[] | Buffer
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string
+  }
+  declare module.exports: Class<uuid>;
+}
+
+declare module "uuid/v1" {
+  declare class v1 {
+    static (
+      options?: {|
+        node?: number[],
+        clockseq?: number,
+        msecs?: number | Date,
+        nsecs?: number
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string
+  }
+
+  declare module.exports: Class<v1>;
+}
+
+declare module "uuid/v4" {
+  declare class v4 {
+    static (
+      options?: {|
+        random?: number[],
+        rng?: () => number[] | Buffer
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string
+  }
+
+  declare module.exports: Class<v4>;
+}
+
+declare module "uuid/v5" {
+  declare class v5 {
+    static (
+      name?: string | number[],
+      namespace?: string | number[],
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string
+  }
+
+  declare module.exports: Class<v5>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -520,6 +520,18 @@
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -816,6 +828,26 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -903,6 +935,15 @@
         "browserslist": "2.11.3",
         "invariant": "2.2.2",
         "semver": "5.5.0"
+      }
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "6.22.0"
       }
     },
     "babel-register": {
@@ -1558,6 +1599,12 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "flow-bin": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.66.0.tgz",
+      "integrity": "sha1-qW3ecBXcM0P9VSp7SWPAK+cFyiY=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -2362,14 +2409,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2378,6 +2417,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3015,11 +3062,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -5049,15 +5091,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5083,6 +5116,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -5190,6 +5232,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8flags": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "eslint": "^4.17.0",
+    "flow-bin": "^0.66.0",
     "mocha": "^5.0.0",
     "nyc": "^11.4.1"
   }

--- a/src/simperium/jsondiff/diff_match_patch.js
+++ b/src/simperium/jsondiff/diff_match_patch.js
@@ -1,4 +1,3 @@
-module.exports = diff_match_patch;
 
 /**
  * Diff Match and Patch
@@ -29,7 +28,7 @@ module.exports = diff_match_patch;
  * Class containing the diff, match and patch methods.
  * @constructor
  */
-function diff_match_patch() {
+export default function diff_match_patch() {
 
   // Defaults.
   // Redefine these in your program to override the defaults.
@@ -65,9 +64,9 @@ function diff_match_patch() {
  * [[DIFF_DELETE, 'Hello'], [DIFF_INSERT, 'Goodbye'], [DIFF_EQUAL, ' world.']]
  * which means: delete 'Hello', add 'Goodbye' and keep ' world.'
  */
-var DIFF_DELETE = -1;
-var DIFF_INSERT = 1;
-var DIFF_EQUAL = 0;
+export const DIFF_DELETE = -1;
+export const DIFF_INSERT = 1;
+export const DIFF_EQUAL = 0;
 
 /** @typedef {{0: number, 1: string}} */
 diff_match_patch.Diff;
@@ -2183,13 +2182,3 @@ diff_match_patch.patch_obj.prototype.toString = function() {
   }
   return text.join('').replace(/%20/g, ' ');
 };
-
-
-// Export these global variables so that they survive Google's JS compiler.
-// In a browser, 'this' will be 'window'.
-// Users of node.js should 'require' the uncompressed version since Google's
-// JS compiler may break the following exports for non-browser environments.
-module.exports['diff_match_patch'] = diff_match_patch;
-module.exports['DIFF_DELETE'] = DIFF_DELETE;
-module.exports['DIFF_INSERT'] = DIFF_INSERT;
-module.exports['DIFF_EQUAL'] = DIFF_EQUAL;

--- a/src/simperium/jsondiff/index.js
+++ b/src/simperium/jsondiff/index.js
@@ -1,8 +1,9 @@
-import JSONDiff from './jsondiff'
-import diff_match_patch from './diff_match_patch'
+// @flow
+import { JSONDiff } from './jsondiff'
+import type { ObjectOperationSet } from './jsondiff';
 
-export { JSONDiff as jsondiff, diff_match_patch }
+export type { ObjectOperationSet }
 
-export default function init( options ) {
-	return new JSONDiff( options );
-}
+const jsondiff = new JSONDiff( { list_diff: false } );
+
+export { jsondiff as default };

--- a/src/simperium/jsondiff/jsondiff.js
+++ b/src/simperium/jsondiff/jsondiff.js
@@ -1,14 +1,10 @@
-var diff_match_patch = require('./diff_match_patch');
+import diff_match_patch, { DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT } from './diff_match_patch';
 
 // stolen from https://raw.github.com/Simperium/jsondiff/master/src/jsondiff.js
-(function() {
-  var jsondiff,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-    __hasProp = Object.prototype.hasOwnProperty;
+const __hasProp = Object.prototype.hasOwnProperty;
+const __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-  jsondiff = (function() {
-
-    function jsondiff(options) {
+    export default function jsondiff(options) {
       this.options = options || {list_diff: true};
       this.patch_apply_with_offsets = __bind(this.patch_apply_with_offsets, this);
       this.transform_object_diff = __bind(this.transform_object_diff, this);
@@ -611,11 +607,3 @@ var diff_match_patch = require('./diff_match_patch');
     text = text.substring(nullPadding.length, text.length - nullPadding.length);
     return text;
   };
-
-    return jsondiff;
-
-  })();
-
-  module.exports = jsondiff;
-
-}).call();

--- a/src/simperium/jsondiff/jsondiff.js
+++ b/src/simperium/jsondiff/jsondiff.js
@@ -1,10 +1,12 @@
 import diff_match_patch, { DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT } from './diff_match_patch';
 
+export { jsondiff as JSONDiff };
+
 // stolen from https://raw.github.com/Simperium/jsondiff/master/src/jsondiff.js
 const __hasProp = Object.prototype.hasOwnProperty;
 const __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-    export default function jsondiff(options) {
+    function jsondiff(options: ?{ list_diff: boolean } ) {
       this.options = options || {list_diff: true};
       this.patch_apply_with_offsets = __bind(this.patch_apply_with_offsets, this);
       this.transform_object_diff = __bind(this.transform_object_diff, this);

--- a/src/simperium/jsondiff/jsondiff.js.flow
+++ b/src/simperium/jsondiff/jsondiff.js.flow
@@ -1,0 +1,29 @@
+// @flow
+export type Options = { list_diff: boolean };
+
+declare export class JSONDiff {
+  constructor( options: ?Options): JSONDiff;
+  transform_object_diff( workingChanges: ObjectOperationSet, upstreamChanges: ObjectOperationSet, base: {}): ObjectOperationSet;
+  apply_object_diff( changes: ObjectOperationSet, base: {}): {};
+  object_diff( base: {}, modified: {} ): ObjectOperationSet;
+}
+
+export type ObjectOperationSet = { [key: string]: Operation }
+type ListOperationSet = { [index: number]: Operation };
+
+export type Operation
+  = AddOperation
+  | RemoveOperation
+  | ReplaceOperation
+  | IncrementOperation
+  | ListOperation
+  | ObjectOperation
+  | DiffMatchPatchOperation
+
+type AddOperation = { o: '+', v: any };
+type RemoveOperation = { o: '-' };
+type ReplaceOperation = { o: 'r', v: any };
+type IncrementOperation = { o: 'I', v: number };
+type ListOperation = { o: 'L', v: { [index: number]: Operation } };
+type ObjectOperation = { o: 'O', v: ObjectOperationSet };
+type DiffMatchPatchOperation = { o: 'd', v: string };

--- a/src/simperium/util/change.js
+++ b/src/simperium/util/change.js
@@ -1,13 +1,59 @@
-import { v4 as uuid } from 'uuid'
+// @flow
+import uuid from 'uuid/v4'
 import jsondiff from '../jsondiff'
+import type { ObjectOperationSet } from '../jsondiff';
 
-const changeTypes = {
+/**
+ * Valid change types for bucket operations
+ */
+export type BucketChangeType = '-' | 'M';
+
+/**
+ * Identifies an object within a bucket on simperium
+ */
+type BucketObjectID = string
+/**
+ * Identifies a unique change operation that a client sends to simperium
+ */
+type ChangeID = string
+/**
+ * A more descriptive type for the modifications present in a
+ * bucket change operation.
+ */
+type BucketObjectModification = ObjectOperationSet
+
+/**
+ * An operation that modifies an object within a bucket.
+ */
+type BucketModifyOperation = {
+	o: 'M',
+	id: BucketObjectID,
+	ccid: ChangeID,
+	v: BucketObjectModification,
+	sv?: number
+}
+
+/**
+ * An operation that deletes an object from a bucket.
+ */
+type BucketRemoveOperation = {
+	o: '-',
+	id: BucketObjectID,
+	ccid: ChangeID
+}
+
+/**
+ * Union type of the two possible operations that can modify data inside
+ * a bucket.
+ */
+export type BucketOperation = BucketModifyOperation | BucketRemoveOperation;
+
+const { transform_object_diff, apply_object_diff, object_diff } = jsondiff;
+
+const changeTypes: { [name: string]: BucketChangeType } = {
 	MODIFY: 'M',
-	REMOVE: '-',
-	ADD: '+'
+	REMOVE: '-'
 };
-
-const { object_diff, transform_object_diff, apply_object_diff } = jsondiff( {list_diff: false} )
 
 export {
 	changeTypes as type,
@@ -17,46 +63,73 @@ export {
 	apply_diff as apply
 }
 
-function modify( id, version, patch ) {
-	return { o: changeTypes.MODIFY, id: id, ccid: uuid.v4(), v: patch };
+/**
+ * Creates a BucketModifyOperation that can be sent to simperium.
+ *
+ * @param { string } id - Bucket object id
+ * @param { number } version - the version number of the object to be modified
+ * @param { {} } patch - the set of operations to be applied to the object at the given version
+ * @returns { {} } a bucket change operation that can be sent to simperium
+ */
+function modify( id: BucketObjectID, version: number, patch: BucketObjectModification ): BucketModifyOperation {
+	return { o: 'M', id: id, ccid: uuid(), v: patch };
 }
 
-function buildChange( type, id, object, ghost ) {
-	return buildChangeFromOrigin( type, id, ghost.version, object, ghost.data );
-}
-
-function buildChangeFromOrigin( type, id, version, target, origin ) {
-	var changeData = {
-		o: type,
+/**
+ * Creates a bucket change for the given bucket object id. The ghost is used to produce
+ * the necessary change operations for simperium.
+ *
+ * @param { string } type - bucket change type, '-' to delete the object, 'M' to modify
+ * @param { string } id - the bucket object id for the object to modify
+ * @param { object } object - the properties the object will be updated to
+ * @param { {version: number, data: {}} } ghost - the version and properties that are present on simperium
+ * @returns { object } the bucket operation that produces the modifications to the object on simperium
+ */
+function buildChange( type: BucketChangeType, id: string, object: {}, ghost: { version: number, data: {} } ) {
+	// Remove operations have no source version or diff
+	if ( type === '-' ) return {
+		o: '-',
 		id: id,
-		ccid: uuid.v4()
+		ccid: uuid()
 	};
 
-	// Remove operations have no source version or diff
-	if ( type === changeTypes.REMOVE ) return changeData;
+	const change: BucketModifyOperation = {
+		o: 'M',
+		id: id,
+		ccid: uuid(),
+		v: object_diff( ghost.data, object )
+	}
+	if ( ghost.version > 0 ) change.sv = ghost.version;
 
-	if ( version > 0 ) changeData.sv = version;
-
-	changeData.v = object_diff( origin, target );
-
-	return changeData;
+	return change;
 }
 
-function compressChanges( changes, origin ) {
-	var modified;
+/**
+ * Given a sequential list of changes to apply to an object, combine them
+ * into a single change. In terms of git, think of it as a squash.
+ *
+ * @param { Array<{}> } changes - list of changes that apply to a given base
+ * @param { object } origin - the base the changes apply to
+ * @returns { ?object } the combined changes. If any changes delete the object the result is null
+ */
+function compressChanges( changes: BucketOperation[], origin: {} ): ?BucketObjectModification {
 
 	if ( changes.length === 0 ) {
 		return {};
 	}
 
 	if ( changes.length === 1 ) {
-		return changes[0].v;
+		const change = changes[0];
+		if ( change.o === 'M' ) {
+			return change.v;
+		}
+		return null;
 	}
 
-	modified = changes.reduce( function( from, change ) {
+	const modified = changes.reduce( ( from, change ) => {
 		// deletes when, any changes after a delete are ignored
 		if ( from === null ) return null;
-		if ( from.o === changeTypes.REMOVE ) return null;
+		if ( change.o === '-' ) return null;
 		return apply_object_diff( from, change.v );
 	}, origin );
 
@@ -65,10 +138,26 @@ function compressChanges( changes, origin ) {
 	return object_diff( origin, modified );
 }
 
-function rebase( local_diff, remote_diff, origin ) {
-	return transform_object_diff( local_diff, remote_diff, origin );
+/**
+ * Rebases the set of local modifications on top of upstream changes and returns
+ * the object that results from those changes.
+ *
+ * @param { object } modifications - the modifications that apply to the base
+ * @param { object } upstream - the upsteram modifications that apply to the base
+ * @param { object } base - the object where the changes diverge
+ * @returns { object } the object that results from rebasing modifications on top of upstream changes
+ */
+function rebase( modifications: BucketObjectModification, upstream: BucketObjectModification, base: {} ) {
+	return transform_object_diff( modifications, upstream, base );
 }
 
-function apply_diff( patch, object ) {
-	return apply_object_diff( object, patch );
+/**
+ * Applies the modifications to the base object and returns the changed object.
+ *
+ * @param { object } modifications - the set of modifications to apply to base
+ * @param { object } base - the object to be modified
+ * @returns { object } the object that results from applying the modifications
+ */
+function apply_diff( modifications: BucketObjectModification, base: {} ) {
+	return apply_object_diff( base, modifications );
 }

--- a/src/simperium/util/index.js
+++ b/src/simperium/util/index.js
@@ -1,3 +1,4 @@
+// @flow
 import * as change from './change'
 import parseMessage from './parse_message'
 import parseVersionMessage from './parse_version_message'

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -10,7 +10,7 @@ import { v4 as uuid } from 'uuid'
 import Bucket from '../../src/simperium/bucket'
 import mockBucketStore from './mock_bucket_store'
 
-const differ = jsondiff()
+const differ = jsondiff
 const diff = differ.object_diff.bind( differ )
 const cycle = ( ... fns ) => ( ... args ) => {
 	const [ head, ... rest ] = fns


### PR DESCRIPTION
Updates `JSONDiff` and `utils/change` with jsdoc and flowtype definitions.

- `JSONDiff` and `diff_match_patch` updated to use es6 modules
- Adds flow type definitions for jsondiff objects. 
- Adds flow type definitions for bucket change operations
- adds doc blocks for change util functions

This moves us into a direction that will allow us to provide clarity to the `Channel` module. For instance it's no longer a mystery what changes look like in the local change queue:

```js
/**
 * An operation that modifies an object within a bucket.
 */
type BucketModifyOperation = {
	o: 'M',
	id: BucketObjectID,
	ccid: ChangeID,
	v: BucketObjectModification,
	sv?: number
}

/**
 * An operation that deletes an object from a bucket.
 */
type BucketRemoveOperation = {
	o: '-',
	id: BucketObjectID,
	ccid: ChangeID
}

/**
 * Union type of the two possible operations that can modify data inside
 * a bucket.
 */
export type BucketOperation = BucketModifyOperation | BucketRemoveOperation;

```

And `JSONDiff` becomes a lot less cryptic:

```js
export type ObjectOperationSet = { [key: string]: Operation }
type ListOperationSet = { [index: number]: Operation };

export type Operation
  = AddOperation
  | RemoveOperation
  | ReplaceOperation
  | IncrementOperation
  | ListOperation
  | ObjectOperation
  | DiffMatchPatchOperation

type AddOperation = { o: '+', v: any };
type RemoveOperation = { o: '-' };
type ReplaceOperation = { o: 'r', v: any };
type IncrementOperation = { o: 'I', v: number };
type ListOperation = { o: 'L', v: ListOperationSet };
type ObjectOperation = { o: 'O', v: ObjectOperationSet };
type DiffMatchPatchOperation = { o: 'd', v: string };
```

The JSONDiff flow type definitions were placed in a companion `jsondiff.js.flow` file because the `jsondiff.js` file is quite a mess.