### PR TITLE
Pass additional arguments to the bucket.update emit

### DIFF
--- a/src/simperium/bucket.js
+++ b/src/simperium/bucket.js
@@ -234,7 +234,7 @@ Bucket.prototype.get = function( id, callback ) {
  *
  * @param {String} id - the bucket id for the object to update
  * @param {Object} data - object literal to replace the object data with
-  * @param {Object} updateInfo - object containing data about a remote change
+ * @param {Object} remoteUpdateInfo - object containing data about a remote change
  * @param {Object} [updateInfo.original] - the original object before the udpate
  * @param {Object} [updateInfo.patch] - the JSONDiff patch to apply to the object
  * @param {Boolean} [updateInfo.isIndexing] - true if the bucket is currently indexing
@@ -243,10 +243,10 @@ Bucket.prototype.get = function( id, callback ) {
  * @param {?bucketStoreGetCallback} callback - executed when object is updated localy
  * @returns {Promise<Object>} - update data
  */
-Bucket.prototype.update = function( id, data, updateInfo, options, callback ) {
+Bucket.prototype.update = function( id, data, remoteUpdateInfo, options, callback ) {
 	// Callback could be 3rd or 4th argument
-	if ( typeof updateInfo === 'function' ) {
-		callback = updateInfo;
+	if ( typeof remoteUpdateInfo === 'function' ) {
+		callback = remoteUpdateInfo;
 		options = { sync: true };
 	} else if ( typeof options === 'function' ) {
 		callback = options;
@@ -259,7 +259,7 @@ Bucket.prototype.update = function( id, data, updateInfo, options, callback ) {
 
 	const task = this.storeAPI.update( id, data, this.isIndexing )
 		.then( bucketObject => {
-			this.emit( 'update', id, bucketObject.data, updateInfo );
+			this.emit( 'update', id, bucketObject.data, remoteUpdateInfo );
 			this.channel.update( bucketObject, options.sync );
 			return bucketObject;
 		} );

--- a/src/simperium/bucket.js
+++ b/src/simperium/bucket.js
@@ -215,7 +215,7 @@ Bucket.prototype.reload = function() {
  */
 Bucket.prototype.add = function( data, callback ) {
 	var id = uuid();
-	return this.update( { id, data }, callback );
+	return this.update( id, data, callback );
 };
 
 /**
@@ -245,8 +245,11 @@ Bucket.prototype.get = function( id, callback ) {
  */
 Bucket.prototype.update = function( id, data, updateInfo, options, callback ) {
 	// Callback could be 3rd or 4th argument
-	if ( typeof updateInfo === 'function' || typeof options === 'function' ) {
-		callback = typeof updateInfo === 'function' ? updateInfo : options;
+	if ( typeof updateInfo === 'function' ) {
+		callback = updateInfo;
+		options = { sync: true };
+	} else if ( typeof options === 'function' ) {
+		callback = options;
 		options = { sync: true };
 	}
 
@@ -308,7 +311,7 @@ Bucket.prototype.getVersion = function( id, callback ) {
  */
 Bucket.prototype.touch = function( id, callback ) {
 	const task = this.storeAPI.get( id )
-		.then( object => this.update( { id: object.id, data: object.data } ) );
+		.then( object => this.update( object.id, object.data ) );
 
 	return deprecateCallback( callback, task );
 };

--- a/test/simperium/bucket_test.js
+++ b/test/simperium/bucket_test.js
@@ -39,7 +39,7 @@ describe( 'Bucket', () => {
 		const id = 'thing',
 			data = {one: 'two'};
 
-		bucket.update( { id, data }, function() {
+		bucket.update( id, data, function() {
 			bucket.get( id, function( err, savedObject ) {
 				deepEqual( data, savedObject );
 				done();
@@ -51,7 +51,7 @@ describe( 'Bucket', () => {
 		const id = 'thing',
 			data = {one: 'two'}
 
-		bucket.update( { id, data }, function() {
+		bucket.update( id, data, function() {
 			bucket.get( id, function( err, savedObject ) {
 				deepEqual( data, savedObject );
 				done();

--- a/test/simperium/bucket_test.js
+++ b/test/simperium/bucket_test.js
@@ -37,11 +37,11 @@ describe( 'Bucket', () => {
 
 	it( 'should store object update callback', ( done ) => {
 		const id = 'thing',
-			object = {one: 'two'};
+			data = {one: 'two'};
 
-		bucket.update( id, object, null, null, null, function() {
+		bucket.update( { id, data }, function() {
 			bucket.get( id, function( err, savedObject ) {
-				deepEqual( object, savedObject );
+				deepEqual( data, savedObject );
 				done();
 			} );
 		} );
@@ -49,11 +49,11 @@ describe( 'Bucket', () => {
 
 	it( 'should update with options callback', ( done ) => {
 		const id = 'thing',
-			object = {one: 'two'}
+			data = {one: 'two'}
 
-		bucket.update( id, object, null, null, null, {}, function() {
+		bucket.update( { id, data }, function() {
 			bucket.get( id, function( err, savedObject ) {
-				deepEqual( object, savedObject );
+				deepEqual( data, savedObject );
 				done();
 			} )
 		} )

--- a/test/simperium/bucket_test.js
+++ b/test/simperium/bucket_test.js
@@ -39,7 +39,7 @@ describe( 'Bucket', () => {
 		const id = 'thing',
 			object = {one: 'two'};
 
-		bucket.update( id, object, function() {
+		bucket.update( id, object, null, null, null, function() {
 			bucket.get( id, function( err, savedObject ) {
 				deepEqual( object, savedObject );
 				done();
@@ -51,7 +51,7 @@ describe( 'Bucket', () => {
 		const id = 'thing',
 			object = {one: 'two'}
 
-		bucket.update( id, object, {}, function() {
+		bucket.update( id, object, null, null, null, {}, function() {
 			bucket.get( id, function( err, savedObject ) {
 				deepEqual( object, savedObject );
 				done();
@@ -99,4 +99,3 @@ describe( 'Bucket', () => {
 		} );
 	} );
 } );
-

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -266,7 +266,7 @@ describe( 'Channel', function() {
 				}, reject );
 			} );
 
-			bucket.update( key, {title: 'hello world'}, function() {
+			bucket.update( key, {title: 'hello world'}, null, null, null, function() {
 				channel.handleMessage( 'c:' + JSON.stringify( [{
 					o: '-', ev: 1, cv: 'cv1', id: key
 				}] ) );

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -108,8 +108,7 @@ describe( 'Channel', function() {
 				done();
 			} );
 
-			const updateArgs = {id: '12345', data: {content: 'Hola mundo!'}}
-			bucket.update( updateArgs );
+			bucket.update( '12345', {content: 'Hola mundo!'});
 		} );
 
 		it( 'should not send a change with an empty diff', function( done ) {
@@ -122,7 +121,7 @@ describe( 'Channel', function() {
 					channel.once( 'unmodified', function() {
 						done();
 					} );
-					bucket.update( {id: 'thing', data} );
+					bucket.update( 'thing', data );
 				} );
 		} );
 
@@ -137,16 +136,16 @@ describe( 'Channel', function() {
 			channel.on( 'send', fn.counts( 1, checkSent ) );
 
 			channel.on( 'send', function() {
-				bucket.update( { id, data: data2 } );
+				bucket.update( id, data2 );
 			} )
 
+			const objectId = '123456';
 			channel.localQueue.on( 'wait', function( id ) {
 				equal( id, objectId );
 				done();
 			} );
 
-			const objectId = '123456';
-			bucket.update( {id: objectId, data} );
+			bucket.update( objectId, data );
 		} );
 
 		it( 'should acknowledge sent change', function( done ) {
@@ -161,7 +160,7 @@ describe( 'Channel', function() {
 				acknowledge( channel, msg );
 			} );
 
-			bucket.update( { id: 'mock-id', data } );
+			bucket.update( 'mock-id', data );
 		} );
 
 		it( 'should ignore duplicate change error if nothing to acknowledge', ( done ) => {
@@ -228,12 +227,12 @@ describe( 'Channel', function() {
 
 			const id = '123';
 			channel.once( 'send', function() {
-				bucket.update( {id, data: {title: 'hello again world'}} );
+				bucket.update( id, {title: 'hello again world'} );
 				bucket.remove( id );
 			} );
 
 			store.put( '123', 3, {title: 'hello world'} ).then( function() {
-				bucket.update( {id, data: {title: 'goodbye world'}} );
+				bucket.update( id, {title: 'goodbye world'} );
 			} );
 		} );
 
@@ -268,7 +267,7 @@ describe( 'Channel', function() {
 				}, reject );
 			} );
 
-			bucket.update( {id: key, data: {title: 'hello world'}}, function() {
+			bucket.update( key, {title: 'hello world'}, function() {
 				channel.handleMessage( 'c:' + JSON.stringify( [{
 					o: '-', ev: 1, cv: 'cv1', id: key
 				}] ) );
@@ -323,7 +322,7 @@ describe( 'Channel', function() {
 
 			const id = '123';
 			store.put( id, 3, {title: 'hello world'} ).then( function() {
-				bucket.update( {id, data: {title: 'goodbye world!!'}} );
+				bucket.update( id, {title: 'goodbye world!!'} );
 			} );
 		} );
 
@@ -355,7 +354,7 @@ describe( 'Channel', function() {
 			}] ) );
 
 			// We're changing "Hello world" to "Goodbye world"
-			bucket.update( {id: key, data: {title: 'Goodbye world'}} );
+			bucket.update( key, {title: 'Goodbye world'} );
 		} ) );
 
 		it( 'should emit errors on the bucket instance', ( done ) => {
@@ -429,7 +428,7 @@ describe( 'Channel', function() {
 					acknowledge( channel, msg );
 				} );
 
-				bucket.update( {id: 'mock-id', data} );
+				bucket.update( 'mock-id', data );
 			} );
 
 			it( 'should get version', ( done ) => {

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -108,7 +108,8 @@ describe( 'Channel', function() {
 				done();
 			} );
 
-			bucket.update( '12345', {content: 'Hola mundo!'} );
+			const updateArgs = {id: '12345', data: {content: 'Hola mundo!'}}
+			bucket.update( updateArgs );
 		} );
 
 		it( 'should not send a change with an empty diff', function( done ) {
@@ -121,7 +122,7 @@ describe( 'Channel', function() {
 					channel.once( 'unmodified', function() {
 						done();
 					} );
-					bucket.update( 'thing', data );
+					bucket.update( {id: 'thing', data} );
 				} );
 		} );
 
@@ -131,12 +132,12 @@ describe( 'Channel', function() {
 				checkSent = function() {
 					throw new Error( 'Sent too many changes' );
 				},
-				objectId = '123456';
+				id = '123456';
 
 			channel.on( 'send', fn.counts( 1, checkSent ) );
 
 			channel.on( 'send', function() {
-				bucket.update( objectId, data2 );
+				bucket.update( { id, data: data2 } );
 			} )
 
 			channel.localQueue.on( 'wait', function( id ) {
@@ -144,8 +145,8 @@ describe( 'Channel', function() {
 				done();
 			} );
 
-			objectId = '123456';
-			bucket.update( objectId, data );
+			const objectId = '123456';
+			bucket.update( {id: objectId, data} );
 		} );
 
 		it( 'should acknowledge sent change', function( done ) {
@@ -160,7 +161,7 @@ describe( 'Channel', function() {
 				acknowledge( channel, msg );
 			} );
 
-			bucket.update( 'mock-id', data );
+			bucket.update( { id: 'mock-id', data } );
 		} );
 
 		it( 'should ignore duplicate change error if nothing to acknowledge', ( done ) => {
@@ -225,13 +226,14 @@ describe( 'Channel', function() {
 
 			channel.localQueue.on( 'wait', validate );
 
+			const id = '123';
 			channel.once( 'send', function() {
-				bucket.update( '123', {title: 'hello again world'} );
-				bucket.remove( '123' );
+				bucket.update( {id, data: {title: 'hello again world'}} );
+				bucket.remove( id );
 			} );
 
 			store.put( '123', 3, {title: 'hello world'} ).then( function() {
-				bucket.update( '123', {title: 'goodbye world'} );
+				bucket.update( {id, data: {title: 'goodbye world'}} );
 			} );
 		} );
 
@@ -266,7 +268,7 @@ describe( 'Channel', function() {
 				}, reject );
 			} );
 
-			bucket.update( key, {title: 'hello world'}, null, null, null, function() {
+			bucket.update( {id: key, data: {title: 'hello world'}}, function() {
 				channel.handleMessage( 'c:' + JSON.stringify( [{
 					o: '-', ev: 1, cv: 'cv1', id: key
 				}] ) );
@@ -319,8 +321,9 @@ describe( 'Channel', function() {
 				} );
 			} );
 
-			store.put( '123', 3, {title: 'hello world'} ).then( function() {
-				bucket.update( '123', {title: 'goodbye world!!'} );
+			const id = '123';
+			store.put( id, 3, {title: 'hello world'} ).then( function() {
+				bucket.update( {id, data: {title: 'goodbye world!!'}} );
 			} );
 		} );
 
@@ -352,7 +355,7 @@ describe( 'Channel', function() {
 			}] ) );
 
 			// We're changing "Hello world" to "Goodbye world"
-			bucket.update( key, {title: 'Goodbye world'} );
+			bucket.update( {id: key, data: {title: 'Goodbye world'}} );
 		} ) );
 
 		it( 'should emit errors on the bucket instance', ( done ) => {
@@ -426,7 +429,7 @@ describe( 'Channel', function() {
 					acknowledge( channel, msg );
 				} );
 
-				bucket.update( 'mock-id', data );
+				bucket.update( {id: 'mock-id', data} );
 			} );
 
 			it( 'should get version', ( done ) => {

--- a/test/simperium/default_storage_test.js
+++ b/test/simperium/default_storage_test.js
@@ -14,7 +14,7 @@ describe( 'default store', () => {
 		const id = 'thing',
 			data = {one: 'two'};
 
-		return bucket.update( id, data )
+		return bucket.update( {id, data} )
 			.then( () => bucket.get( id ) )
 			.then( ( object ) => {
 				deepEqual( object, { data, id } );
@@ -25,7 +25,7 @@ describe( 'default store', () => {
 		const id = 'thing',
 			data = {one: 'two'}
 
-		return bucket.update( id, data )
+		return bucket.update( {id, data} )
 			.then( () => bucket.get( id ) )
 			.then( ( object ) => {
 				deepEqual( object, { data, id } );

--- a/test/simperium/default_storage_test.js
+++ b/test/simperium/default_storage_test.js
@@ -14,7 +14,7 @@ describe( 'default store', () => {
 		const id = 'thing',
 			data = {one: 'two'};
 
-		return bucket.update( {id, data} )
+		return bucket.update( id, data )
 			.then( () => bucket.get( id ) )
 			.then( ( object ) => {
 				deepEqual( object, { data, id } );
@@ -25,7 +25,7 @@ describe( 'default store', () => {
 		const id = 'thing',
 			data = {one: 'two'}
 
-		return bucket.update( {id, data} )
+		return bucket.update( id, data )
 			.then( () => bucket.get( id ) )
 			.then( ( object ) => {
 				deepEqual( object, { data, id } );


### PR DESCRIPTION
Refs: https://github.com/Automattic/simplenote-electron/issues/976

Since 0.3.2 the bucket.update() emit event was not passing necessary arguments that Simplenote needed to do a 3-way data merge if needed.

The arguments are a little long and hard to grok now though, should we change them to an object that gets passed in so we don't mess up the order?