### PR TITLE
Test: Stop re-sending duplicate changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1726,7 +1726,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1747,12 +1748,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1767,17 +1770,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1894,7 +1900,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1906,6 +1913,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1920,6 +1928,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1927,12 +1936,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1951,6 +1962,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2038,7 +2050,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2050,6 +2063,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2135,7 +2149,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2171,6 +2186,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2190,6 +2206,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2233,12 +2250,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2278,6 +2297,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2431,7 +2451,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2461,7 +2482,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2483,6 +2505,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -2721,6 +2744,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2880,6 +2904,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -2927,6 +2952,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3248,7 +3274,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3332,6 +3359,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3378,7 +3406,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3644,7 +3673,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -4264,13 +4294,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -240,6 +240,7 @@ internal.handleChangeError = function( err, change, acknowledged ) {
 
 			break;
 		case CODE_DUPLICATE_CHANGE:
+			// no need to do anything else here - we already got this
 			internal.updateAcknowledged.call( this, acknowledged );
 			break;
 		case CODE_EMPTY_RESPONSE: // Change causes no change, just acknowledge it

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -435,6 +435,18 @@ describe( 'Channel', function() {
 			} );
 		} );
 
+		it( 'should acknowledge sent changes when receiving 409', ( done ) =>{
+			channel.localQueue.sent['mock-id'] = { fake: 'change', ccid: 'dup-ccid', id: 'mock-id' };
+
+			bucket.once( 'error', done );
+
+			// when we get the 409 we should acknowledge the change and clear the sent queue
+			channel.once( 'sent', () => done( 'Should not send a duplicate change' ) );
+			channel.once( 'acknowledge', () => done() );
+
+			channel.handleMessage( 'c:[{"error": 409, "ccids":["dup-ccid"], "id": "mock-id"}]' );
+		} );
+
 		describe( 'with synced object', () => {
 			beforeEach( ( done ) => {
 				var data = { title: 'hola mundo' };
@@ -455,37 +467,6 @@ describe( 'Channel', function() {
 					equal( version, 1 );
 					done()
 				} );
-			} );
-
-			it( 'should handle a 409', ( done ) =>{
-				const expectedChange = { fake: 'change', ccid: 'dup-ccid', id: 'mock-id' };
-				channel.localQueue.sent['mock-id'] = { fake: 'change', ccid: 'dup-ccid', id: 'mock-id' };
-
-				/**
-				 * If the 409 is not handled the bucket will error
-				 */
-				bucket.once( 'error', ( e ) => {
-					done( e );
-				} );
-
-				/**
-				 * After successfully handling the 409 we should have an acknowledged
-				 * local change matching the duplicated ccid error.
-				 */
-				channel.once( 'acknowledge', ( id, change ) => {
-					try {
-						equal( id, 'mock-id' );
-						deepEqual( expectedChange, change )
-						done();
-					} catch ( error ) {
-						done( error );
-					}
-				} );
-
-				/**
-				 * Simulate receiving a 409
-				 */
-				channel.handleMessage( 'c:[{"error": 409, "ccids":["dup-ccid"], "id": "mock-id"}]' );
 			} );
 		} );
 	} );

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -423,7 +423,7 @@ describe( 'Channel', function() {
 
 			channel.once( 'send', () => {
 				// we should sent out our change the first time
-				channel.on( 'error', done );
+				bucket.once( 'error', done );
 				channel.localQueue.once( 'queued', () => done( 'Should not queue duplicate changes' ) );
 				channel.once( 'acknowledge', () => done() );
 


### PR DESCRIPTION
See: Automattic/simplenote-electron/issues/1579
Related work in #74 

Discovered an issue where the local Simperium client was re-sending
changes that had already been accepted by the server. This was caused
by not recognizing the duplicate-change error and also by not
acknowledging that a queued change had come back from the server in
a change list.

In this patch we're adding the duplicate-change handler to remove
a change from the app's queue when the server tells us that it has
already been applied. ~We're also watching the incoming changes and
if we discover that we have a change queued up that also comes in
from the server then we go ahead and remove it from the queue.~

After this change we should see a reduction in duplicate-change load
~and also a particular bug might disappear: double-writing of changes
that occurred during network loss~.

**Testing**

Testing is a bit tricky but I found it easiest to link this library with the
Simplenote electron app and build them together via `npm link`

```bash
git clone …node-simperium.git
git clone …simplenote-electron.git
cd node-simperium
npm checkout fix/stop-re-sending-duplicate-changes
npm install
npm run prepare
npm link
cd ..
cd simplenote-electron
npm link simperium
npm install
npm run dev
```

~Follow the steps in Automattic/simplenote-electron/issues/1579 to confirm if
this change fixes that specific issue~. Smoke-test other interactions to make
sure that this doesn't cause unintended breakages elsewhere.