### PR TITLE
Unit Test: 409 server error

### DIFF
--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid'
 
 const UNKNOWN_CV = '?';
 const CODE_INVALID_VERSION = 405;
+const CODE_DUPLICATE_CHANGE = 409;
 const CODE_EMPTY_RESPONSE = 412;
 const CODE_INVALID_DIFF = 440;
 
@@ -237,6 +238,9 @@ internal.handleChangeError = function( err, change, acknowledged ) {
 				this.localQueue.dequeueChangesFor( change.id );
 			}
 
+			break;
+		case CODE_DUPLICATE_CHANGE:
+			internal.updateAcknowledged.call( this, acknowledged );
 			break;
 		case CODE_EMPTY_RESPONSE: // Change causes no change, just acknowledge it
 			internal.updateAcknowledged.call( this, acknowledged );

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -420,7 +420,7 @@ describe( 'Channel', function() {
 			beforeEach( ( done ) => {
 				var data = { title: 'hola mundo' };
 
-				channel.on( 'acknowledge', function() {
+				channel.once( 'acknowledge', function() {
 					done();
 				} );
 

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -437,6 +437,37 @@ describe( 'Channel', function() {
 					done()
 				} );
 			} );
+
+			it( 'should handle a 409', ( done ) =>{
+				const expectedChange = { fake: 'change', ccid: 'dup-ccid', id: 'mock-id' };
+				channel.localQueue.sent['mock-id'] = { fake: 'change', ccid: 'dup-ccid', id: 'mock-id' };
+
+				/**
+				 * If the 409 is not handled the bucket will error
+				 */
+				bucket.once( 'error', ( e ) => {
+					done( e );
+				} );
+
+				/**
+				 * After successfully handling the 409 we should have an acknowledged
+				 * local change matching the duplicated ccid error.
+				 */
+				channel.once( 'acknowledge', ( id, change ) => {
+					try {
+						equal( id, 'mock-id' );
+						deepEqual( expectedChange, change )
+						done();
+					} catch ( error ) {
+						done( error );
+					}
+				} );
+
+				/**
+				 * Simulate receiving a 409
+				 */
+				channel.handleMessage( 'c:[{"error": 409, "ccids":["dup-ccid"], "id": "mock-id"}]' );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Unit test to simulate a client receiving a 409 error from the server for a change that originated from the same client.

The fix is intentionally left out which should be as simple as:

```diff
diff --git a/src/simperium/channel.js b/src/simperium/channel.js
index 4f59d15..15db61b 100644
--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -238,6 +238,7 @@ internal.handleChangeError = function( err, change, acknowledged ) {
 			}
 
 			break;
+		case 409:
 		case CODE_EMPTY_RESPONSE: // Change causes no change, just acknowledge it
 			internal.updateAcknowledged.call( this, acknowledged );
 			break;
```