### PR TITLE
Fix: Stop transforming and forgetting changes we are waiting on

### DIFF
--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -116,19 +116,21 @@ internal.updateObjectVersion = function( id, version, data, original, patch, ack
 	// we need to provide a way for the current client to respond to
 	// a potential conflict if it has modifications that have not been synced
 	if ( !acknowledged ) {
-		changes = this.localQueue.dequeueChangesFor( id );
-		localModifications = change_util.compressChanges( changes, original );
-		remoteModifications = patch;
-		transformed = change_util.transform( localModifications, remoteModifications, original );
-		update = data;
+		if ( ! this.localQueue.sent[id] ) {
+			changes = this.localQueue.dequeueChangesFor( id );
+			localModifications = change_util.compressChanges( changes, original );
+			remoteModifications = patch;
+			transformed = change_util.transform( localModifications, remoteModifications, original );
+			update = data;
 
-		// apply the transformed patch and emit the update
-		if ( transformed ) {
-			patch = transformed;
-			update = change_util.apply( transformed, data );
-			// queue up the new change
-			change = change_util.modify( id, version, patch );
-			this.localQueue.queue( change );
+			// apply the transformed patch and emit the update
+			if (transformed) {
+				patch = transformed;
+				update = change_util.apply( transformed, data );
+				// queue up the new change
+				change = change_util.modify( id, version, patch );
+				this.localQueue.queue( change );
+			}
 		}
 
 		notify = this.emit.bind( this, 'update', id, update, original, patch, this.isIndexing );

--- a/test/simperium/channel_test.js
+++ b/test/simperium/channel_test.js
@@ -95,6 +95,56 @@ describe( 'Channel', function() {
 			channel.localQueue.start();
 		} );
 
+		it( 'should break', ( done ) => {
+			channel.store.put( 'thing', 1, {content: 'AC'} ).then( () => {
+
+				channel.localQueue.sent.thing = {
+					id: 'thing',
+					sv: 1,
+					o: 'M',
+					v: {
+						content: {
+							o: 'd',
+							v: '=2\t+D'
+						}
+					},
+					ccid: 'local-offline'
+				}
+
+				channel.handleMessage( 'c:' + JSON.stringify( [{
+					id: 'thing',
+					sv: 1,
+					ev: 2,
+					o: 'M',
+					v: {
+						content: {
+							o: 'd',
+							v: '=1\t+B\t=1'
+						}
+					},
+					ccids: ['remote']
+				}] ) )
+
+				channel.on( 'send', done );
+
+				channel.handleMessage( 'c:' + JSON.stringify( [{
+					id: 'thing',
+					sv: 2,
+					ev: 3,
+					o: 'M',
+					v: {
+						content: {
+							o: 'd',
+							v: '=3\t+D'
+						}
+					},
+					ccids: ['local-offline']
+				}] ) )
+
+				channel.once( 'acknowledge', () => done() );
+			} )
+		} );
+
 		it( 'should send change to create object', function( done ) {
 			channel.on( 'send', function( data ) {
 				var marker = data.indexOf( ':' ),


### PR DESCRIPTION
**DO NOT MERGE** - this PR is incomplete

When we have sent changes for an entity and are waiting for server's
response we might first receive updates from the server that represent
changes which another client made to the same entity.

In those cases we have been forgetting about the changes we sent and
then transforming our local changes to the new updates. To our client it
appears like we have made changes locally on top of the remote changes
when in reality we only made changes to the previous base version of the
entity.

The result of this forgetfulness is that we replay changes that should
only happen once. This might appear in the form of duplicated content
but could expose itself in other forms.

In this patch we're guarding the transformation based on the presence of
those waiting changes. If we get updates while waiting, simply apply
those updates to our internal ghost and let the client handle our
original submission once it comes back. If it comes back confirmed by
the server we'll be able to apply the updated patch which the server
created. If it gets rejected we will end up sending the full copy of our
changes and mess up the note _but_ the original data should remian in
the history.