### PR TITLE
Refactor: Clarify names in `updateObjectVersion`

### DIFF
--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -104,7 +104,7 @@ internal.removeAndSend = function( id ) {
 
 // We've receive a full object from the network. Update the local instance and
 // notify of the new object version
-internal.updateObjectVersion = function( entityId, version, entityData, original, incomingPatch, localChange ) {
+internal.updateObjectVersion = function( entityId, version, entityData, ghostData, incomingPatch, localChange ) {
 	// if the change originated locally then all we need to do
 	// is update the ghost copy and acknowledge the update
 	if (localChange) {
@@ -126,15 +126,15 @@ internal.updateObjectVersion = function( entityId, version, entityData, original
 	 */
 
 	const queuedLocalChangeList = this.localQueue.dequeueChangesFor( entityId );
-	const compressedLocalChange = change_util.compressChanges( queuedLocalChangeList, original );
-	const patchWithLocalChanges = change_util.transform( compressedLocalChange, incomingPatch, original );
+	const compressedLocalChange = change_util.compressChanges( queuedLocalChangeList, ghostData );
+	const patchWithLocalChanges = change_util.transform( compressedLocalChange, incomingPatch, ghostData );
 	const transformedEntityData = change_util.apply( patchWithLocalChanges, entityData );
 	this.localQueue.queue( change_util.modify( entityId, version, patchWithLocalChanges ) );
 
 	return this
 		.store
 		.put( entityId, version, entityData )
-		.then( this.emit.bind( this, 'update', entityId, transformedEntityData, original, incomingPatch, this.isIndexing ) );
+		.then( this.emit.bind( this, 'update', entityId, transformedEntityData, ghostData, incomingPatch, this.isIndexing ) );
 };
 
 internal.removeObject = function( id, acknowledged ) {

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -125,16 +125,16 @@ internal.updateObjectVersion = function( entityId, version, entityData, original
 	 *  - Re-submit them to the outbound queue
 	 */
 
-	const locallyQueuedChanges = this.localQueue.dequeueChangesFor( entityId );
-	const localModifications = change_util.compressChanges( locallyQueuedChanges, original );
-	const patchWithLocalChanges = change_util.transform( localModifications, incomingPatch, original );
-	const updatedData = change_util.apply( patchWithLocalChanges, entityData );
+	const queuedLocalChangeList = this.localQueue.dequeueChangesFor( entityId );
+	const compressedLocalChange = change_util.compressChanges( queuedLocalChangeList, original );
+	const patchWithLocalChanges = change_util.transform( compressedLocalChange, incomingPatch, original );
+	const transformedEntityData = change_util.apply( patchWithLocalChanges, entityData );
 	this.localQueue.queue( change_util.modify( entityId, version, patchWithLocalChanges ) );
 
 	return this
 		.store
 		.put( entityId, version, entityData )
-		.then( this.emit.bind( this, 'update', entityId, updatedData, original, incomingPatch, this.isIndexing ) );
+		.then( this.emit.bind( this, 'update', entityId, transformedEntityData, original, incomingPatch, this.isIndexing ) );
 };
 
 internal.removeObject = function( id, acknowledged ) {


### PR DESCRIPTION
This is prep-work for fixing the "cross-wires" problem.
See #74 

When reading through `updateObjectVersion` I was having trouble
understanding how the function should flow and what the variables held.
In this change I've replaced mutable variables with `const`s and renamed
many of the variables to focus more on their role than on their essence.

The function flow has also been tossed upside-down in order to provide
an early-abort for local changes which allows us to remove a level of
nesting when handling remote changes.

**There should be no functional changes to the application as a result
of this pull request.** Please **smoke-test** and feel free to use the `npm link`
method to build `simplenote-electron` with this branch.