### PR TITLE
Run simplenote

### DIFF
--- a/bin/simplenote
+++ b/bin/simplenote
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+mkdir -p tmp
+
+# Build latest simplenote
+if [[ ! -d "tmp/simplenote-electron" ]]; then
+  git clone https://github.com/automattic/simplenote-electron.git tmp/simplenote-electron --branch develop  
+  cd tmp/simplenote-electron
+  npm install
+fi
+npm link ../../
+NODE_ENV=development npx webpack-dev-server --config ./webpack.config.js --content-base dist --port 4000 --open


### PR DESCRIPTION
At this point `node-simperium`s only reason for life is `simplenote-electron`.

To help remove testing friction this adds a bin script that:

1. Checks out Automattic/simplenote-electron to `tmp/simplenote-electron`
2. `npm install` and `npm link ../../` so that the current `node-simperium` source you are working on will be used by `simplenote-electron`
3. Boots the `simplenote-electron` web server and opens your browser.

Now when asking for a review you should hopefully be able to start with:

> Run `./bin/simplenote`

### How to test

- Run `./bin/simplenote`
- Wait a bit while
  - git clones the repo
  - npm installs the deps
  - weback-dev-server transpiles the JS
- When it's down, your browser should be opened (on macOS)

If on linux or Windows you will have to open http://localhost:4000 yourself.

### Future Improvements

- If `node-simperium` is to live on in its own repository Puppeteer could be leveraged to fully automate the browser testing.
- The source in `simplenote-electron/lib/simperium` could make its way into this library so the interface between the browser and `node-simperium` could be more easily tested using a JSDom style library.