### PR TITLE
Tests: Allow running async/await in test files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3323,6 +3323,27 @@
         "regexpu-core": "^4.5.4"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3714,6 +3714,44 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -6237,6 +6275,11 @@
           "dev": true
         }
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "flow": "flow",
     "test:coverage": "nyc npm test",
-    "test": "mocha --reporter dot --require @babel/register --require babel-polyfill test/**",
+    "test": "mocha --reporter dot --require @babel/register --require @babel/polyfill test/**",
     "babel": "babel -q -d lib/ src/",
     "lint": "eslint --quiet src/",
     "prepare": "npm run babel"
@@ -21,7 +21,7 @@
   "author": "",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
+    "@babel/polyfill": "^7.6.0",
     "uuid": "3.3.3",
     "websocket": "1.0.30"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "flow": "flow",
     "test:coverage": "nyc npm test",
-    "test": "mocha --reporter dot --require @babel/register test/**",
+    "test": "mocha --reporter dot --require @babel/register --require babel-polyfill test/**",
     "babel": "babel -q -d lib/ src/",
     "lint": "eslint --quiet src/",
     "prepare": "npm run babel"
@@ -21,6 +21,7 @@
   "author": "",
   "license": "BSD-2-Clause",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "uuid": "3.3.3",
     "websocket": "1.0.30"
   },


### PR DESCRIPTION
We have previously not been able to use `async/await` in our test files.
This can lead to particularly deep nesting or callback-passing when we
are trying to sequence events for the purpose of the test.

In this change we're adding the `babel-polyfill` to allow us to use
those constructs and _linearize_ the async flows.

**Testing**

Since this only impacts tests, just run `npm test`
Apart from that it's indeterminate if the patch was successful or not.