### PR TITLE
Tests for `simperium/client`

### DIFF
--- a/src/simperium/index.js
+++ b/src/simperium/index.js
@@ -2,8 +2,25 @@ import Client from './client'
 import Auth from './auth'
 import * as util from './util'
 
-export default function( appId, token, options ) {
-	return new Client( appId, token, options );
+/**
+ * A Client is the main interface to Simperium.
+ *
+ * @param {String} appId - Simperium application id
+ * @param {String} token - User access token
+ * @param {Object} options - configuration options for the client
+ * @param {ghostStoreProvider} [options.ghostStoreProvider=defaultGhostStoreProvider]
+ *            - factory function for creating ghost store instances
+ * @param {bucketStoreProvider} [options.objectStoreProvider=defaultObjectStoreProvider]
+ *            - factory function for creating object store instances
+ * @param {number} [options.heartbeatInterval=4] - heartbeat interval for maintaining connection status with Simperium.com
+ * @param {websocketClientProvider} [options.websocketClientProvider] - WebSocket transport, if not provided tries to use window.WebSocket
+ * @returns {Object} Simperium client.
+ */
+export default function createClient( appId, token, options ) {
+	// Attaching an noop error listener. The behavior is to not
+	// throw any runtime errors. This is something worth changing
+	// but applications should be made aware when that is the case.
+	return new Client( appId, token, options ).on( 'error', () => {} );
 }
 
 export { Auth, Client, util }

--- a/test/simperium/auth_test.js
+++ b/test/simperium/auth_test.js
@@ -3,6 +3,7 @@ import https from 'https'
 import { equal, deepEqual } from 'assert'
 import { EventEmitter } from 'events'
 
+const originalRequest = https.request;
 const stub = ( respond ) => {
 	https.request = ( options, handler ) => {
 		const req = new EventEmitter()
@@ -20,6 +21,11 @@ const stubResponse = ( data ) => stub( ( body, handler ) => {
 
 describe( 'Auth', () => {
 	let auth;
+
+	after( () => {
+		// Unstub it
+		https.request = originalRequest;
+	} );
 
 	beforeEach( () => {
 		auth = buildAuth( 'token', 'secret' );

--- a/test/simperium/client_test.js
+++ b/test/simperium/client_test.js
@@ -1,0 +1,133 @@
+import { Client } from '../../src/simperium/client';
+import * as events from 'events';
+import { equal, deepEqual, ok } from 'assert';
+
+class MockWebSocket extends events.EventEmitter {
+	constructor( ...args ) {
+		super( ...args );
+		this.outbox = [];
+	}
+
+	close() {
+		// noop
+	}
+
+	send( msg ) {
+		this.emit( 'send', msg );
+		this.outbox.push( msg );
+	}
+}
+
+describe( 'Client', () => {
+	let socket, client;
+
+	const websocketClientProvider = ( url ) => {
+		socket = new MockWebSocket( url );
+		return socket;
+	}
+
+	beforeEach( () => {
+		client = new Client( 'MOCK_ID', 'MOCK_TOKEN', {
+			websocketClientProvider
+		} );
+	} )
+
+	afterEach( () => {
+		client.end();
+	} );
+
+	it( 'connects', ( done ) => {
+		client.once( 'connect', () => {
+			client.end();
+			done();
+		} );
+
+		socket.onopen()
+	} );
+
+	it( 'emits unauthorized when unauthorized', ( done ) => {
+		client.once( 'unauthorized', () => done() );
+
+		client.onUnauthorized();
+	} );
+
+	it( 'ticks heartbeat on message', () => {
+		client.onMessage( { data: 'h:5' } );
+		equal( 5, client.heartbeat.count );
+	} );
+
+	it( 'emits error when fails to send message', ( done ) => {
+		const expected = new Error( 'nope' );
+		socket.send = () => {
+			throw expected;
+		}
+
+		client.once( 'error', ( error ) => {
+			equal( expected, error );
+			done();
+		} )
+
+		client.send();
+	} )
+
+	it( 'sends heartbeat', () => {
+		socket.once( 'send', ( msg ) => {
+			equal( 'h:5', msg )
+		} );
+
+		client.sendHeartbeat( 5 );
+	} )
+
+	it( 'setAccessToken emits access-token and connects', ( done ) => {
+		client.once( 'access-token', ( token ) => {
+			client.once( 'connect', () => {
+				done();
+			} )
+
+			equal( 'mock-token', token );
+			socket.onopen();
+		} );
+
+		client.setAccessToken( 'mock-token' );
+	} );
+
+	it( 'parses channel specific message', ( done ) => {
+		client.once( 'channel:500', ( msg ) => {
+			equal( 'c:blah', msg );
+			done();
+		} );
+		client.parseMessage( { data: '500:c:blah' } );
+	} );
+
+	it( 'creates bucket and sends init message', ( done ) => {
+		client.on( 'error', done );
+
+		client.bucket( 'ships' );
+
+		socket.once( 'send', ( msg ) => {
+			const preamble = '0:init:';
+
+			equal( msg.slice( 0, preamble.length ), '0:init:' );
+
+			const payload = JSON.parse( msg.slice( preamble.length ) );
+
+			equal( '1.1', payload.api );
+			equal( '0.0.1', payload.version );
+			equal( 'MOCK_ID', payload.app_id );
+			equal( 'MOCK_TOKEN', payload.token );
+			equal( 'node-simperium', payload.library );
+			equal( 'ships', payload.name );
+			ok(
+				( /^node-[-a-z0-9]{1,}$/ ).test( payload.clientid ),
+				`Invalid clientid ${ payload.clientid }`
+			);
+
+			done();
+		} );
+
+		// We expect the client to attempt to authorize a bucket
+		// once the socket connects
+		socket.onopen();
+	} );
+} );
+

--- a/test/simperium/client_test.js
+++ b/test/simperium/client_test.js
@@ -1,6 +1,6 @@
 import { Client } from '../../src/simperium/client';
 import * as events from 'events';
-import { equal, deepEqual, ok } from 'assert';
+import { equal, ok } from 'assert';
 
 class MockWebSocket extends events.EventEmitter {
 	constructor( ...args ) {

--- a/test/simperium/heartbeat_test.js
+++ b/test/simperium/heartbeat_test.js
@@ -1,0 +1,34 @@
+import { Heartbeat } from '../../src/simperium/client';
+
+import { equal } from 'assert';
+
+describe( 'Heartbeat', () => {
+	it( 'timeouts', ( done ) => {
+		// If the heartbeat does not "tick" within
+		// the given time, it will emit a `timeout`
+		// This indicates that the client has not received
+		// a heartbeat message from simperium
+		const heartbeat = new Heartbeat( 0.03 );
+
+		heartbeat.once( 'timeout', () => {
+			heartbeat.stop();
+			done();
+		} );
+
+		heartbeat.start();
+	} );
+
+	it( 'ticks', ( done ) => {
+		// When the heartbeat is "ticked" by a simperium
+		// network message it increments its counter and
+		// emits a 'beat'
+		const heartbeat = new Heartbeat( 0.03, ( count ) => {
+			equal( count, 501 );
+			done();
+			heartbeat.stop();
+		} );
+
+		heartbeat.start();
+		heartbeat.tick( 500 )
+	} )
+} );

--- a/test/simperium/reconnection_timer_test.js
+++ b/test/simperium/reconnection_timer_test.js
@@ -1,0 +1,37 @@
+import { ReconnectionTimer } from '../../src/simperium/client';
+
+import { equal } from 'assert';
+
+describe( 'ReconnectionTimer', () => {
+	it( 'increments the interval', ( done ) => {
+		let current = 0;
+		const timer = new ReconnectionTimer( () => 30, ( attempt ) => {
+			equal( current, attempt )
+			current += 1;
+
+			if ( current === 3 ) {
+				timer.stop();
+				done();
+			} else {
+				timer.start();
+			}
+		} );
+
+		timer.start();
+	} );
+
+	it( 'uses a default interval', () => {
+		const timer = new ReconnectionTimer();
+		equal( 1000, timer.interval() );
+	} );
+
+	it( 'restart resets the interval and starts the timer', ( done ) => {
+		const timer = new ReconnectionTimer( () => 0.3, ( attempt ) => {
+			equal( 0, attempt );
+			done();
+		} );
+
+		timer.attempt = 1000;
+		timer.restart();
+	} )
+} );


### PR DESCRIPTION
The `simperium/client` module is the main interface between an application and the features of `node-simperium`. This adds unit tests to increase coverage of that API.


Before:
```
---------------------------|----------|----------|----------|----------|-------------------|
File                       |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
---------------------------|----------|----------|----------|----------|-------------------|
  client.js                |    25.48 |     5.56 |        0 |    26.32 |... 85,289,290,291 |
---------------------------|----------|----------|----------|----------|-------------------|
```

After:
```
  client.js                |    90.57 |    68.42 |    81.82 |    92.21 |... 97,298,300,302 |
```

### Functional Changes

- `websocketClientProvider` added as an option with `option.websocketClientProvider`. The default implementation provides the same functionality as before. This allows for easier unit testing.
- `client.emit( 'error' )` when `client.send` fails. Previously it was swallowing the error. The default is to add a `noop` event listener because the default implementation of `EventEmitter` will throw when `'error'` is emitted with no attached listener. This is to provide the same runtime expectation.