### PR TITLE
Fix Simplenote breaking change

### DIFF
--- a/src/simperium/client.js
+++ b/src/simperium/client.js
@@ -301,3 +301,6 @@ function defaultWebsocketClientProvider( url ) {
 	}
 	return new WebSocketClient( url );
 }
+
+// Simplenote expects this.
+Client.Bucket = Bucket;

--- a/test/simperium/client_test.js
+++ b/test/simperium/client_test.js
@@ -1,4 +1,4 @@
-import { Client } from '../../src/simperium/client';
+import Client from '../../src/simperium/client';
 import * as events from 'events';
 import { equal, ok } from 'assert';
 


### PR DESCRIPTION
Broken in #82 

Simplenote expects `Bucket` to exist as `Client.Bucket`.