### PR TITLE
Fix Channel change processor to always use the latest Ghost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script:
   - npm run lint
   # unit tests with coverage report
   - npm run test:coverage
+  # Flow type check
+  - npx flow
 node_js:
   - "10"
   - "9"

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -10,7 +10,7 @@ type User = {
 };
 
 const fromJSON = ( json: string ): User => {
-	const data: {} = JSON.parse( json );
+	const data = JSON.parse( json );
 	if ( ! data.access_token && typeof data.access_token !== 'string' ) {
 		throw new Error( 'access_token not present' );
 	}
@@ -74,9 +74,10 @@ export class Auth extends EventEmitter {
 	}
 
 	getUrlOptions( path: string ) {
-		const options = url.parse( `${URL}/${ this.appId }/${ path}` );
+		const { port, ...options } = url.parse( `${URL}/${ this.appId }/${ path}` );
 		return {
 			... options,
+			port: port ? Number( port ) : undefined,
 			method: 'POST',
 			headers: {'X-Simperium-API-Key': this.appSecret }
 		};

--- a/src/simperium/channel.js
+++ b/src/simperium/channel.js
@@ -854,11 +854,10 @@ LocalQueue.prototype.compressAndSend = function( id, ghost ) {
 
 	change = buildOperation( sending, ghost );
 	this.queues[id] = [];
-	this.sent[id] = change;
 	if ( change_util.isEmptyChange( change ) ) {
 		return;
 	}
-
+	this.sent[id] = change;
 	this.emit( 'send', change );
 }
 

--- a/src/simperium/util/operation.js
+++ b/src/simperium/util/operation.js
@@ -1,0 +1,30 @@
+/**
+ * @flow
+ */
+import { change } from './';
+import type { BucketOperation, BucketModifyOperation, Data, Ghost } from './change';
+
+export type Operation =
+ | {| type: 'modify', id: string, object: Data |}
+ | {| type: 'remove', id: string |}
+ | {| type: 'full', id: string, originalChange: BucketModifyOperation, object: Data |}
+
+//  var payload = change_util.buildChange( change_util.type.MODIFY, id, object, ghost ),
+
+export default function buildChange( operation: Operation, ghost: Ghost ): BucketOperation {
+	switch ( operation.type ) {
+		case 'modify': {
+			return change.buildChange( 'M', operation.id, operation.object, ghost );
+		}
+		case 'remove': {
+			return change.buildChange( '-', operation.id, {}, ghost );
+		}
+		case 'full': {
+			return { ...operation.originalChange, d: operation.object };
+		}
+		default: {
+			( operation.type: empty );
+			throw new Error( 'Unknown operation type ' + JSON.stringify( operation ) );
+		}
+	}
+}


### PR DESCRIPTION
The strategy was to create the diff at the moment the object sync was signaled.

However, it's possible for a sync to be delayed if the client is already waiting for a response from a previous change for the same object ID.

Once the sent change is acknowledged, it updates the local "ghost" representation which makes all pending changes for that object id's sent change outdated. Their patches were made against the previous ghost version.

With these changes, the Channel does not create the patch until the very last moment. This is also how the Android and iOS clients behave.