### PR TITLE
Fix: Disconnect before reconnecting to prevent duplication

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 # Changelog
 
-## Future Release
+## 1.0.1
+
+ - Disconnect from existing socket connection when connecting [#90](https://github.com/Simperium/node-simperium/pull/90)
+
+## 1.0.0
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {

--- a/src/simperium/client.js
+++ b/src/simperium/client.js
@@ -179,6 +179,10 @@ Client.prototype.sendChannelMessage = function( id, message ) {
 };
 
 Client.prototype.connect = function() {
+	if ( this.open ) {
+		this.disconnect();
+	}
+
 	this.reconnect = true;
 	this.socket = this.options.websocketClientProvider( this.options.url );
 


### PR DESCRIPTION
In Automattic/simplenote-electron we noticed that after signing out of
the application and signing in again we were getting infinite
duplication of changes. This occurred until we quit the app and
restarted it.

We discovered that when signing back in the Simperium client library was
opening a new WebSocket connection without closing the old one. Whenever
the server sent back changes the client got them twice and tried to
update the content twice, which then cascaded duplication without end.

In this patch we're closing the existing connection if it's already open
when we call `connect()`. This probably fixes defects we haven't
associated with this change.

**Testing**

1. Checkout this branch
2. Run `npm run prepare && npm link`
3. Clone Automattic/simplenote-electron
4. In that directory run `npm link simperium && npm run dev`

With this branch `npm link`ed when you logout/login and type something in a note the app should enter your changes and things will work as expected.

Without this branch when you logout/login and type something then you should see after a short delay that you change replays infinitely and duplicates itself.