### PR TITLE
Fix: Second update to diff-match-patch fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+ - Update diff-match-patch to newer revision of surrogate-pair encoding fix
+
 ## 1.0.2
 
  - Update diff-match-patch to fix problem when encoding consecutive surrogate pairs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "repository": {


### PR DESCRIPTION
In 1.0.2 we applied an update from google/diff-match-patch#80 to resolve the
surrogate pair encoding issue.  Since that time we found a bug in the fix and
resolved that and therefore this patch brings those additional updates to
Simeprium.

There previously remained issues when decoding broken patches that already
existed or which came from unpatched versions of the iOS library and also
remained issues when unexpectedly receiving empty diff groups in `toDelta`