### PR TITLE
Add error handling to expose server response during failed auth

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 ## 1.1.2
 
-- Updates the error messaging to include the server reponse during failed authentication [#111](https://github.com/simperium/node-simperium/pull/111)
+- Updates the error messaging to include the server response during failed authentication [#111](https://github.com/simperium/node-simperium/pull/111)
 
 ## 1.1.0 - 1.1.1
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2
+
+- Updates the error messaging to include the server reponse during failed authentication [#111](https://github.com/simperium/node-simperium/pull/111)
+
 ## 1.1.0 - 1.1.1
 
  - Increase usability in other projects by separating `node` and browser modules [#100](https://github.com/Simperium/node-simperium/pull/100)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "browser": {

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -11,11 +11,11 @@ type User = {
 const fromJSON = (json: string): User => {
   try {
     const data = JSON.parse(json);
-    if (!data.access_token && typeof data.access_token !== 'string') {
-      throw new Error('access_token not present');
-    }
   } catch (error) {
     throw new Error(json);
+  }
+  if (!data.access_token && typeof data.access_token !== 'string') {
+    throw new Error('access_token not present');
   }
 	return {
 		options: data,

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -9,8 +9,9 @@ type User = {
 };
 
 const fromJSON = (json: string): User => {
+  let data;
   try {
-    const data = JSON.parse(json);
+    data = JSON.parse(json);
   } catch (error) {
     throw new Error(json);
   }

--- a/src/simperium/auth.js
+++ b/src/simperium/auth.js
@@ -8,11 +8,15 @@ type User = {
 	access_token: string,
 };
 
-const fromJSON = ( json: string ): User => {
-	const data = JSON.parse( json );
-	if ( ! data.access_token && typeof data.access_token !== 'string' ) {
-		throw new Error( 'access_token not present' );
-	}
+const fromJSON = (json: string): User => {
+  try {
+    const data = JSON.parse(json);
+    if (!data.access_token && typeof data.access_token !== 'string') {
+      throw new Error('access_token not present');
+    }
+  } catch (error) {
+    throw new Error(json);
+  }
 	return {
 		options: data,
 		access_token: new String( data.access_token ).toString()


### PR DESCRIPTION
### Description

Currently, if there is an error when trying to Authenticate there is no way to see what the server response is. 
This doesn't allow to handle different reasons for an authentication failure.

On authentication, the response from the server will either be a JSON string with user information or a text error message.
This catches the case where we can't parse the response as JSON and then throws an error with the response.

In clients, we will be able to access the response with something like
`const errorMessage = error.underlyingError.message ?? '';`

### Todo

- [x] Fix Auth tests
- [x] Update release notes
- [x] Update version number