### PR TITLE
Return a message when a 429 http response is received

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.4
+
+- Adds a message response when receiving a 429 HTTP error [#115](https://github.com/simperium/node-simperium/pull/115)
+
 ## 1.1.3
 
 - Fixes a sync issue by reverting the changes from PR #101 [#114](https://github.com/simperium/node-simperium/pull/114)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simperium",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A simperium client for node.js",
   "main": "./lib/simperium/index.js",
   "browser": {

--- a/src/simperium/http-request.browser.js
+++ b/src/simperium/http-request.browser.js
@@ -11,10 +11,10 @@ export default function(
 		xhr.setRequestHeader( 'X-Simperium-API-Key', apiKey );
 
 		xhr.onload = () => {
-			const message = xhr.status === 429 && xhr.responseText === ''
-				? 'too many requests'
-				: xhr.responseText;
-			resolve(message);
+			if ( xhr.status === 429 && xhr.responseText === '' ) {
+				return resolve('too many requests');
+			}
+			resolve(xhr.responseText);
 		};
 		xhr.onerror = () => reject();
 

--- a/src/simperium/http-request.browser.js
+++ b/src/simperium/http-request.browser.js
@@ -12,7 +12,7 @@ export default function(
 
 		xhr.onload = () => {
 			const message = xhr.status === 429 && xhr.responseText === ''
-				? 'too many retries'
+				? 'too many requests'
 				: xhr.responseText;
 			resolve(message);
 		};

--- a/src/simperium/http-request.browser.js
+++ b/src/simperium/http-request.browser.js
@@ -10,7 +10,12 @@ export default function(
 		xhr.open( 'POST', url );
 		xhr.setRequestHeader( 'X-Simperium-API-Key', apiKey );
 
-		xhr.onload = () => resolve( xhr.responseText );
+		xhr.onload = () => {
+			const message = xhr.status === 429 && xhr.responseText === ''
+				? 'too many retries'
+				: xhr.responseText;
+			resolve(message);
+		};
 		xhr.onerror = () => reject();
 
 		xhr.send( body );


### PR DESCRIPTION
### Description

Currently, node-simperium only returns the response text from HTTP requests. 
This adds a case for handling 429 responses from Simperium, which has an empty response body, and adds a response text which can then be used to handle this error specifically. 

Now in clients if a 429 error is received you can check for it with something like 
`const errorMessage = error.underlyingError.message ?? '';`
`errorMessage === 'too many requests'; // 429 error`

